### PR TITLE
Shorten generated mirror name

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,15 +51,9 @@ Only exception is `-remote-sa-token-path` flag and
 
 In order to make regex matching easier for dns rewrite purposes (see coredns
 example bellow) we use a hardcoded separator between service names and
-namespaces on the generated name for mirrored service.
-We picked that to be `6d6972726f720a` from the hexdump of `mirror`:
+namespaces on the generated name for mirrored service: `73736d`.
 
-```
-$ echo mirror | xxd -p
-6d6972726f720a
-```
-
-The format of the generated name is: `<prefix>-<name>-6d6972726f720a-<namespace>`.
+The format of the generated name is: `<prefix>-<namespace>-73736d-<name>`.
 
 It's possible for this name to exceed the 63 character limit imposed by Kubernetes.
 To guard against this, a Gatekeeper constraint template is provided in
@@ -74,12 +68,12 @@ Refer to the [example](gatekeeper/semaphore-mirror-name-length/example.yaml).
 To create a smoother experience when accessing a service coredns can be
 configured using the `rewrite` functionality:
 ```
-cluster.<target> {
+cluster.example {
     errors
     health
     rewrite continue {
-            name regex ([a-zA-Z0-9-_]*)\.([a-zv0-9-_]*)\.svc\.cluster\.<target> <target>-{1}-6d6972726f720a-{2}.<namespace>.svc.cluster.local
-            answer name <target>-([a-zA-Z0-9-_]*)-6d6972726f720a-([a-zA-Z0-9-_]*)\.<namespace>\.svc\.cluster\.local {1}.{2}.svc.cluster.<target>
+      name regex ([a-zA-Z0-9-_]*\.)?([a-zA-Z0-9-_]*)\.([a-zv0-9-_]*)\.svc\.cluster\.example {1}example-{3}-73736d-{2}.<namespace>.svc.cluster.local
+      answer name ([a-zA-Z0-9-_]*\.)?example-([a-zA-Z0-9-_]*)-73736d-([a-zA-Z0-9-_]*)\.<namespace>\.svc\.cluster\.local {1}{3}.{2}.svc.cluster.example
     }
     kubernetes cluster.local in-addr.arpa ip6.arpa {
       pods insecure

--- a/gatekeeper/semaphore-mirror-name-length/src.rego
+++ b/gatekeeper/semaphore-mirror-name-length/src.rego
@@ -1,13 +1,14 @@
 package semaphoremirrornamelength
 
-name_fmt := "%s-%s-6d6972726f720a-%s"
+# <prefix>-<namespace>-73736d-<name>
+name_fmt := "%s-%s-73736d-%s"
 
 violation[{"msg": msg}] {
   prefix := input.parameters.prefixes[_]
   name := input.review.object.metadata.name
   namespace := input.review.object.metadata.namespace
 
-  mirror_name := sprintf(name_fmt, [prefix, name, namespace])
+  mirror_name := sprintf(name_fmt, [prefix, namespace, name])
   mirror_name_len := count(mirror_name)
   mirror_name_len > 63
 

--- a/gatekeeper/semaphore-mirror-name-length/src_test.rego
+++ b/gatekeeper/semaphore-mirror-name-length/src_test.rego
@@ -30,7 +30,7 @@ test_violation_with_longest_prefix {
   results := violation with input as {
     "parameters": {"prefixes": ["merit", "aws", "gcp"]},
     "review": {"object": {"metadata": {
-      "name": "too-long-with-merit-but-not-other",
+      "name": "too-long-with-merit-but-not-other-prefix",
       "namespace": "example-ns",
     }}},
   }

--- a/gatekeeper/semaphore-mirror-name-length/template.yaml
+++ b/gatekeeper/semaphore-mirror-name-length/template.yaml
@@ -20,14 +20,15 @@ spec:
       rego: |
         package semaphoremirrornamelength
 
-        name_fmt := "%s-%s-6d6972726f720a-%s"
+        # <prefix>-<namespace>-73736d-<name>
+        name_fmt := "%s-%s-73736d-%s"
 
         violation[{"msg": msg}] {
           prefix := input.parameters.prefixes[_]
           name := input.review.object.metadata.name
           namespace := input.review.object.metadata.namespace
 
-          mirror_name := sprintf(name_fmt, [prefix, name, namespace])
+          mirror_name := sprintf(name_fmt, [prefix, namespace, name])
           mirror_name_len := count(mirror_name)
           mirror_name_len > 63
 

--- a/runner_test.go
+++ b/runner_test.go
@@ -89,7 +89,7 @@ func TestAddService(t *testing.T) {
 		Selector:  nil,
 	}
 	expectedSvcs := []TestSvc{TestSvc{
-		Name:      fmt.Sprintf("prefix-test-svc-%s-remote-ns", SEPARATOR),
+		Name:      fmt.Sprintf("prefix-remote-ns-%s-test-svc", Separator),
 		Namespace: "local-ns",
 		Spec:      expectedSpec,
 	}}
@@ -140,7 +140,7 @@ func TestAddHeadlessService(t *testing.T) {
 		Selector:  nil,
 	}
 	expectedSvcs := []TestSvc{TestSvc{
-		Name:      fmt.Sprintf("prefix-test-svc-%s-remote-ns", SEPARATOR),
+		Name:      fmt.Sprintf("prefix-remote-ns-%s-test-svc", Separator),
 		Namespace: "local-ns",
 		Spec:      expectedSpec,
 	}}
@@ -156,7 +156,7 @@ func TestModifyService(t *testing.T) {
 	existingPorts := []v1.ServicePort{v1.ServicePort{Port: 1}}
 	existingSvc := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("prefix-test-svc-%s-remote-ns", SEPARATOR),
+			Name:      fmt.Sprintf("prefix-remote-ns-%s-test-svc", Separator),
 			Namespace: "local-ns",
 		},
 		Spec: v1.ServiceSpec{
@@ -201,7 +201,7 @@ func TestModifyService(t *testing.T) {
 		Selector:  nil,
 	}
 	expectedSvcs := []TestSvc{TestSvc{
-		Name:      fmt.Sprintf("prefix-test-svc-%s-remote-ns", SEPARATOR),
+		Name:      fmt.Sprintf("prefix-remote-ns-%s-test-svc", Separator),
 		Namespace: "local-ns",
 		Spec:      expectedSpec,
 	}}
@@ -217,7 +217,7 @@ func TestModifyServiceNoChange(t *testing.T) {
 	existingPorts := []v1.ServicePort{v1.ServicePort{Port: 1}}
 	existingSvc := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("prefix-test-svc-%s-remote-ns", SEPARATOR),
+			Name:      fmt.Sprintf("prefix-remote-ns-%s-test-svc", Separator),
 			Namespace: "local-ns",
 		},
 		Spec: v1.ServiceSpec{
@@ -291,7 +291,7 @@ func TestServiceSync(t *testing.T) {
 	// Create mirrored service
 	mirroredSvc := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("prefix-test-svc-%s-remote-ns", SEPARATOR),
+			Name:      fmt.Sprintf("prefix-remote-ns-%s-test-svc", Separator),
 			Namespace: "local-ns",
 			Labels:    MirrorLabels,
 		},
@@ -303,7 +303,7 @@ func TestServiceSync(t *testing.T) {
 	// Create stale service
 	staleSvc := &v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("prefix-old-svc-%s-remote-ns", SEPARATOR),
+			Name:      fmt.Sprintf("prefix-old-svc-%s-remote-ns", Separator),
 			Namespace: "local-ns",
 			Labels:    MirrorLabels,
 		},
@@ -344,7 +344,7 @@ func TestServiceSync(t *testing.T) {
 	assert.Equal(t, 1, len(svcs.Items))
 	assert.Equal(
 		t,
-		fmt.Sprintf("prefix-test-svc-%s-remote-ns", SEPARATOR),
+		fmt.Sprintf("prefix-remote-ns-%s-test-svc", Separator),
 		svcs.Items[0].Name,
 	)
 }


### PR DESCRIPTION
The separator we use is unnecessarily long and takes up a lot of real estate.

Other related changes:
  - Rearranged the format of the name so that namespace is before name, this sorts better alphabetically.
  - Made `generateMirrorName` its own function, rather than a method on the runner
  - Remove the handling of an empty prefix in `generateMirrorName`  - this is a required flag so I don't see the utility in producing a name we'll never use.
  - Renamed `SEPARATOR` -> `Separator`. I don't think the capitalization of the former is very Go.
  - Updated gatekeeper constraint template
  - Updated examples
  - Updated README.md