### PR TITLE
gatekeeper: add matchLabels selector to parameters

### DIFF
--- a/gatekeeper/semaphore-mirror-name-length/example.yaml
+++ b/gatekeeper/semaphore-mirror-name-length/example.yaml
@@ -11,6 +11,8 @@ spec:
       matchLabels:
         uw.systems/mirror: "true"
   parameters:
+    matchLabels:
+      uw.systems/mirror: "true"
     prefixes:
       - aws
       - gcp

--- a/gatekeeper/semaphore-mirror-name-length/src_test.rego
+++ b/gatekeeper/semaphore-mirror-name-length/src_test.rego
@@ -49,3 +49,68 @@ test_violation_with_longest_prefix {
 
   count(results) == 1
 }
+
+test_ok_label_missing {
+  results := violation with input as {
+    "parameters": {"matchLabels": {"foo": "bar", "baz": "foo"}, "prefixes": ["merit"]},
+    "review": {"operation": "CREATE", "object": {"metadata": {
+      "name": "this-name-is-far-too-long",
+      "namespace": "this-namespace-is-also-too-long",
+      "labels": {"foo": "bar"},
+    }}},
+  }
+
+  count(results) == 0
+}
+
+test_ok_label_match {
+  results := violation with input as {
+    "parameters": {"matchLabels": {"foo": "bar", "baz": "foo"}, "prefixes": ["merit", "aws", "gcp"]},
+    "review": {"operation": "CREATE", "object": {"metadata": {
+      "name": "example",
+      "namespace": "example-ns",
+      "labels": {"foo": "bar", "baz": "foo"},
+    }}},
+  }
+
+  count(results) == 0
+}
+
+test_ok_label_match_subset {
+  results := violation with input as {
+    "parameters": {"matchLabels": {"foo": "bar", "baz": "foo"}, "prefixes": ["merit", "aws", "gcp"]},
+    "review": {"operation": "CREATE", "object": {"metadata": {
+      "name": "example",
+      "namespace": "example-ns",
+      "labels": {"foo": "bar", "baz": "foo", "another": "label"},
+    }}},
+  }
+
+  count(results) == 0
+}
+
+test_violation_label_match {
+  results := violation with input as {
+    "parameters": {"matchLabels": {"foo": "bar", "baz": "foo"}, "prefixes": ["merit"]},
+    "review": {"operation": "CREATE", "object": {"metadata": {
+      "name": "this-name-is-far-too-long",
+      "namespace": "this-namespace-is-also-too-long",
+      "labels": {"foo": "bar", "baz": "foo"},
+    }}},
+  }
+
+  count(results) == 1
+}
+
+test_violation_label_match_subset {
+  results := violation with input as {
+    "parameters": {"matchLabels": {"foo": "bar", "baz": "foo"}, "prefixes": ["merit"]},
+    "review": {"operation": "CREATE", "object": {"metadata": {
+      "name": "this-name-is-far-too-long",
+      "namespace": "this-namespace-is-also-too-long",
+      "labels": {"foo": "bar", "baz": "foo", "another": "label"},
+    }}},
+  }
+
+  count(results) == 1
+}

--- a/gatekeeper/semaphore-mirror-name-length/template.yaml
+++ b/gatekeeper/semaphore-mirror-name-length/template.yaml
@@ -11,6 +11,10 @@ spec:
         openAPIV3Schema:
           required: [prefixes]
           properties:
+            matchLabels:
+              type: object
+              additionalProperties:
+                type: string
             prefixes:
               type: array
               items:
@@ -23,8 +27,25 @@ spec:
         # <prefix>-<namespace>-73736d-<name>
         name_fmt := "%s-%s-73736d-%s"
 
+        # always match if matchLabels is nil
+        match_labels {
+          not input.parameters.matchLabels
+        }
+
+        # ensure that every key=value pair in matchLabels is also in metadata.labels
+        match_labels {
+          count(input.parameters.matchLabels) == count({label_value | label_value := input.parameters.matchLabels[label_key]; has_label(label_key, label_value)})
+        }
+
+        # check that label_key=label_value is in metadata.labels
+        has_label(label_key, label_value) {
+          input.review.object.metadata.labels[label_key] == label_value
+        }
+
         violation[{"msg": msg}] {
           input.review.operation != "DELETE"
+
+          match_labels
 
           prefix := input.parameters.prefixes[_]
           name := input.review.object.metadata.name


### PR DESCRIPTION
The label selector the controller uses to select remote services is configurable, therefore I purposely omitted any label matching from the policy itself, assuming that using a `labelSelector` on the constaint itself would suffice.

As it turns out, the constraint `labelSelector` will still select the object when the label is removed (because the old object matches the selector). So, in order to support removing the the label from a violating object, the policy needs to check the labels itself.