### PR TITLE
metrics: add kube watcher metrics

### DIFF
--- a/metrics/kube_watcher.go
+++ b/metrics/kube_watcher.go
@@ -1,0 +1,43 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/apimachinery/pkg/watch"
+)
+
+var (
+	kubeWatcherObjects = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "semaphore_service_mirror_kube_watcher_objects",
+		Help: "Number of objects watched, by watcher and kind",
+	},
+		[]string{"watcher", "kind"},
+	)
+	kubeWatcherEvents = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "semaphore_service_mirror_kube_watcher_events_total",
+		Help: "Number of events handled, by watcher, kind and event_type",
+	},
+		[]string{"watcher", "kind", "event_type"},
+	)
+)
+
+func init() {
+	prometheus.MustRegister(
+		kubeWatcherObjects,
+		kubeWatcherEvents,
+	)
+}
+
+func IncKubeWatcherEvents(watcher, kind string, eventType watch.EventType) {
+	kubeWatcherEvents.With(prometheus.Labels{
+		"watcher":    watcher,
+		"kind":       kind,
+		"event_type": string(eventType),
+	}).Inc()
+}
+
+func SetKubeWatcherObjects(watcher, kind string, v float64) {
+	kubeWatcherObjects.With(prometheus.Labels{
+		"watcher": watcher,
+		"kind":    kind,
+	}).Set(v)
+}

--- a/runner_test.go
+++ b/runner_test.go
@@ -328,7 +328,9 @@ func TestServiceSync(t *testing.T) {
 		true,
 	)
 	go testRunner.serviceWatcher.Run()
+	go testRunner.mirrorServiceWatcher.Run()
 	cache.WaitForNamedCacheSync("serviceWatcher", ctx.Done(), testRunner.serviceWatcher.HasSynced)
+	cache.WaitForNamedCacheSync("mirrorServiceWatcher", ctx.Done(), testRunner.mirrorServiceWatcher.HasSynced)
 
 	// ServiceSync will trigger a sync. Verify that old service is deleted
 	if err := testRunner.ServiceSync(); err != nil {


### PR DESCRIPTION
Adds metrics that track the number of watched objects and keep a count of the events received.

Adds watchers for the mirrored services to provide metrics for those too.