### PR TITLE
Sync endpointslices for global services at startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,8 @@ cluster.
     "globalSvcRoutingStrategyLabel": "mirror.semaphore.uw.io/global-service-routing-strategy=local-first",
     "mirrorSvcLabelSelector": "mirror.semaphore.uw.io/mirror-service=true",
     "mirrorNamespace": "semaphore",
-    "serviceSync": true
+    "serviceSync": true,
+    "endpointSliceSync": true
   },
   "localCluster": {
     "name": "local",

--- a/config.go
+++ b/config.go
@@ -51,6 +51,7 @@ type globalConfig struct {
 	MirrorSvcLabelSelector        string `json:"mirrorSvcLabelSelector"`   // Label used to select remote services to mirror
 	MirrorNamespace               string `json:"mirrorNamespace"`          // Local namespace to mirror remote services
 	ServiceSync                   bool   `json:"serviceSync"`              // sync services on startup
+	EndpointSliceSync             bool   `json:"endpointSliceSync"`        // sync endpointslices (for global services) at startup
 }
 
 type localClusterConfig struct {

--- a/kube/endpointslice_watcher.go
+++ b/kube/endpointslice_watcher.go
@@ -101,6 +101,10 @@ func (esw *EndpointSliceWatcher) Stop() {
 	close(esw.stopChannel)
 }
 
+func (esw *EndpointSliceWatcher) HasSynced() bool {
+	return esw.controller.HasSynced()
+}
+
 func (esw *EndpointSliceWatcher) Get(name, namespace string) (*discoveryv1.EndpointSlice, error) {
 	key := namespace + "/" + name
 

--- a/main.go
+++ b/main.go
@@ -181,5 +181,6 @@ func makeGlobalRunner(homeClient, remoteClient *kubernetes.Clientset, name strin
 		gst,
 		localCluster,
 		routingStrategyLabel,
+		global.EndpointSliceSync,
 	)
 }

--- a/utils.go
+++ b/utils.go
@@ -42,8 +42,8 @@ func generateGlobalEndpointSliceName(name string) string {
 	return fmt.Sprintf("gl-%s", name)
 }
 
-func generateEndpointSliceLabels(targetService string) map[string]string {
-	labels := map[string]string{}
+func generateEndpointSliceLabels(baseLabels map[string]string, targetService string) map[string]string {
+	labels := baseLabels
 	labels["kubernetes.io/service-name"] = targetService
 	labels["endpointslice.kubernetes.io/managed-by"] = "semaphore-service-mirror"
 	return labels


### PR DESCRIPTION
EndpointSlices are not tied with the Services they target and have indeendent
lifecycles. We should be able to delete stale EndpointSlice mirros when the
global runner starts, in order to avoid sending traffic to dead targets.