### PR TITLE
Fix inconsistency between config keys and README value

### DIFF
--- a/config.go
+++ b/config.go
@@ -46,12 +46,12 @@ func (d *Duration) UnmarshalJSON(b []byte) error {
 
 // globalConfig will keep configuration that applies globally on the operator
 type globalConfig struct {
-	GlobalSvcLabelSelector        string `json:"globalSvcLabelSelector"`   // Label used to select global services to mirror
-	GlobalSvcRoutingStrategyLabel string `json:"globalSvcRoutingStrategy"` // Label used to enable topology aware hints for global services
-	MirrorSvcLabelSelector        string `json:"mirrorSvcLabelSelector"`   // Label used to select remote services to mirror
-	MirrorNamespace               string `json:"mirrorNamespace"`          // Local namespace to mirror remote services
-	ServiceSync                   bool   `json:"serviceSync"`              // sync services on startup
-	EndpointSliceSync             bool   `json:"endpointSliceSync"`        // sync endpointslices (for global services) at startup
+	GlobalSvcLabelSelector        string `json:"globalSvcLabelSelector"`        // Label used to select global services to mirror
+	GlobalSvcRoutingStrategyLabel string `json:"globalSvcRoutingStrategyLabel"` // Label used to enable topology aware hints for global services
+	MirrorSvcLabelSelector        string `json:"mirrorSvcLabelSelector"`        // Label used to select remote services to mirror
+	MirrorNamespace               string `json:"mirrorNamespace"`               // Local namespace to mirror remote services
+	ServiceSync                   bool   `json:"serviceSync"`                   // sync services on startup
+	EndpointSliceSync             bool   `json:"endpointSliceSync"`             // sync endpointslices (for global services) at startup
 }
 
 type localClusterConfig struct {

--- a/config_test.go
+++ b/config_test.go
@@ -26,12 +26,7 @@ func TestConfig(t *testing.T) {
 
 	globalConfigOnly := []byte(`
 {
-  "global": {
-    "globalSvcLabelSelector": "globalLabel",
-    "globalSvcTopologyLabel": "globalTopologyLabel",
-    "mirrorSvcLabelSelector": "label",
-    "mirrorNamespace": "sys-semaphore"
-  },
+  "global": {},
   "localCluster":{
     "name": "local_cluster"
   }
@@ -75,6 +70,10 @@ func TestConfig(t *testing.T) {
 	rawFullConfig := []byte(`
 {
   "global": {
+    "globalSvcLabelSelector": "globalLabel",
+    "globalSvcRoutingStrategyLabel": "globalTopologyLabel",
+    "mirrorSvcLabelSelector": "mirrorLabel",
+    "mirrorNamespace": "sys-semaphore",
     "serviceSync": true
   },
   "localCluster": {
@@ -98,12 +97,12 @@ func TestConfig(t *testing.T) {
   ]
 }
 `)
-	config, err := parseConfig(rawFullConfig, testFlagGlobalSvcLabelSelector, testFlagGlobalSvcTopologyLabel, testFlagMirrorSvcLabelSelector, testFlagMirrorNamespace)
+	config, err := parseConfig(rawFullConfig, "", "", "", "")
 	assert.Equal(t, nil, err)
-	assert.Equal(t, testFlagGlobalSvcLabelSelector, config.Global.GlobalSvcLabelSelector)
-	assert.Equal(t, testFlagGlobalSvcTopologyLabel, config.Global.GlobalSvcRoutingStrategyLabel)
-	assert.Equal(t, testFlagMirrorSvcLabelSelector, config.Global.MirrorSvcLabelSelector)
-	assert.Equal(t, testFlagMirrorNamespace, config.Global.MirrorNamespace)
+	assert.Equal(t, "globalLabel", config.Global.GlobalSvcLabelSelector)
+	assert.Equal(t, "globalTopologyLabel", config.Global.GlobalSvcRoutingStrategyLabel)
+	assert.Equal(t, "mirrorLabel", config.Global.MirrorSvcLabelSelector)
+	assert.Equal(t, "sys-semaphore", config.Global.MirrorNamespace)
 	assert.Equal(t, true, config.Global.ServiceSync)
 	assert.Equal(t, "local_cluster", config.LocalCluster.Name)
 	assert.Equal(t, "/path/to/kube/config", config.LocalCluster.KubeConfigPath)


### PR DESCRIPTION
README suggests setting `globalSvcRoutingStrategyLabel`, but the json parser
expects a different name. Fix the inconsistency between doc and actual config