### PR TITLE
Fix metrics labels to be able to separate series

### DIFF
--- a/global_runner.go
+++ b/global_runner.go
@@ -56,41 +56,45 @@ func newGlobalRunner(client, watchClient kubernetes.Interface, name, namespace, 
 		sync:                 sync,
 		syncMirrorLabels:     mirrorLabels,
 	}
-	runner.serviceQueue = newQueue(fmt.Sprintf("%s-gl-service", name), runner.reconcileGlobalService)
+	runner.serviceQueue = newQueue(fmt.Sprintf("%s-global-service", name), runner.reconcileGlobalService)
 	runner.endpointSliceQueue = newQueue(fmt.Sprintf("%s-endpointslice", name), runner.reconcileEndpointSlice)
+	runnerName := fmt.Sprintf("global-%s", name)
 
 	// Create and initialize a service watcher
 	serviceWatcher := kube.NewServiceWatcher(
-		fmt.Sprintf("gl-%s-serviceWatcher", name),
+		fmt.Sprintf("%s-serviceWatcher", name),
 		watchClient,
 		resyncPeriod,
 		runner.ServiceEventHandler,
 		labelselector,
 		metav1.NamespaceAll,
+		runnerName,
 	)
 	runner.serviceWatcher = serviceWatcher
 	runner.serviceWatcher.Init()
 
 	// Create and initialize an endpointslice watcher
 	endpointSliceWatcher := kube.NewEndpointSliceWatcher(
-		fmt.Sprintf("gl-%s-endpointSliceWatcher", name),
+		fmt.Sprintf("%s-endpointSliceWatcher", name),
 		watchClient,
 		resyncPeriod,
 		runner.EndpointSliceEventHandler,
 		labelselector,
 		metav1.NamespaceAll,
+		runnerName,
 	)
 	runner.endpointSliceWatcher = endpointSliceWatcher
 	runner.endpointSliceWatcher.Init()
 
 	// Create and initialize an endpointslice watcher for mirrored endpointslices
 	mirrorEndpointSliceWatcher := kube.NewEndpointSliceWatcher(
-		fmt.Sprintf("mirror-%s-endpointSliceWatcher", name),
+		fmt.Sprintf("%s-mirrorEndpointSliceWatcher", name),
 		watchClient,
 		resyncPeriod,
 		nil,
 		labels.Set(mirrorLabels).String(),
 		namespace,
+		runnerName,
 	)
 	runner.mirrorEndpointSliceWatcher = mirrorEndpointSliceWatcher
 	runner.mirrorEndpointSliceWatcher.Init()

--- a/kube/endpoints_watcher.go
+++ b/kube/endpoints_watcher.go
@@ -30,9 +30,10 @@ type EndpointsWatcher struct {
 	labelSelector string
 	name          string
 	namespace     string
+	runner        string // Name of the parent runner of the watcher. Used for metrics to distinguish series.
 }
 
-func NewEndpointsWatcher(name string, client kubernetes.Interface, resyncPeriod time.Duration, handler EndpointsEventHandler, labelSelector, namespace string) *EndpointsWatcher {
+func NewEndpointsWatcher(name string, client kubernetes.Interface, resyncPeriod time.Duration, handler EndpointsEventHandler, labelSelector, namespace, runner string) *EndpointsWatcher {
 	return &EndpointsWatcher{
 		ctx:           context.Background(),
 		client:        client,
@@ -42,6 +43,7 @@ func NewEndpointsWatcher(name string, client kubernetes.Interface, resyncPeriod 
 		labelSelector: labelSelector,
 		name:          name,
 		namespace:     namespace,
+		runner:        runner,
 	}
 }
 
@@ -79,8 +81,8 @@ func (ew *EndpointsWatcher) Init() {
 }
 
 func (ew *EndpointsWatcher) handleEvent(eventType watch.EventType, oldObj, newObj *v1.Endpoints) {
-	metrics.IncKubeWatcherEvents(ew.name, "endpoints", eventType)
-	metrics.SetKubeWatcherObjects(ew.name, "endpoints", float64(len(ew.store.List())))
+	metrics.IncKubeWatcherEvents(ew.name, "endpoints", ew.runner, eventType)
+	metrics.SetKubeWatcherObjects(ew.name, "endpoints", ew.runner, float64(len(ew.store.List())))
 
 	if ew.eventHandler != nil {
 		ew.eventHandler(eventType, oldObj, newObj)

--- a/kube/endpointslice_watcher.go
+++ b/kube/endpointslice_watcher.go
@@ -30,9 +30,10 @@ type EndpointSliceWatcher struct {
 	labelSelector string
 	name          string
 	namespace     string
+	runner        string // Name of the parent runner of the watcher. Used for metrics to distinguish series.
 }
 
-func NewEndpointSliceWatcher(name string, client kubernetes.Interface, resyncPeriod time.Duration, handler EndpointSliceEventHandler, labelSelector, namespace string) *EndpointSliceWatcher {
+func NewEndpointSliceWatcher(name string, client kubernetes.Interface, resyncPeriod time.Duration, handler EndpointSliceEventHandler, labelSelector, namespace, runner string) *EndpointSliceWatcher {
 	return &EndpointSliceWatcher{
 		ctx:           context.Background(),
 		client:        client,
@@ -42,6 +43,7 @@ func NewEndpointSliceWatcher(name string, client kubernetes.Interface, resyncPer
 		labelSelector: labelSelector,
 		name:          name,
 		namespace:     namespace,
+		runner:        runner,
 	}
 }
 
@@ -81,8 +83,8 @@ func (esw *EndpointSliceWatcher) Init() {
 }
 
 func (esw *EndpointSliceWatcher) handleEvent(eventType watch.EventType, oldObj, newObj *discoveryv1.EndpointSlice) {
-	metrics.IncKubeWatcherEvents(esw.name, "endpointslice", eventType)
-	metrics.SetKubeWatcherObjects(esw.name, "endpointslice", float64(len(esw.store.List())))
+	metrics.IncKubeWatcherEvents(esw.name, "endpointslice", esw.runner, eventType)
+	metrics.SetKubeWatcherObjects(esw.name, "endpointslice", esw.runner, float64(len(esw.store.List())))
 
 	if esw.eventHandler != nil {
 		esw.eventHandler(eventType, oldObj, newObj)

--- a/metrics/kube_watcher.go
+++ b/metrics/kube_watcher.go
@@ -10,13 +10,13 @@ var (
 		Name: "semaphore_service_mirror_kube_watcher_objects",
 		Help: "Number of objects watched, by watcher and kind",
 	},
-		[]string{"watcher", "kind"},
+		[]string{"watcher", "kind", "runner"},
 	)
 	kubeWatcherEvents = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "semaphore_service_mirror_kube_watcher_events_total",
 		Help: "Number of events handled, by watcher, kind and event_type",
 	},
-		[]string{"watcher", "kind", "event_type"},
+		[]string{"watcher", "kind", "event_type", "runner"},
 	)
 )
 
@@ -27,17 +27,19 @@ func init() {
 	)
 }
 
-func IncKubeWatcherEvents(watcher, kind string, eventType watch.EventType) {
+func IncKubeWatcherEvents(watcher, kind, runner string, eventType watch.EventType) {
 	kubeWatcherEvents.With(prometheus.Labels{
 		"watcher":    watcher,
 		"kind":       kind,
 		"event_type": string(eventType),
+		"runner":     runner,
 	}).Inc()
 }
 
-func SetKubeWatcherObjects(watcher, kind string, v float64) {
+func SetKubeWatcherObjects(watcher, kind, runner string, v float64) {
 	kubeWatcherObjects.With(prometheus.Labels{
 		"watcher": watcher,
 		"kind":    kind,
+		"runner":  runner,
 	}).Set(v)
 }

--- a/metrics/queue.go
+++ b/metrics/queue.go
@@ -44,7 +44,7 @@ var (
 	queueLongestRunningProcessor = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "semaphore_service_mirror_queue_longest_running_processor_seconds",
-			Help: "Unfinished work in seconds, by queue name",
+			Help: "Longest running processor, by queue name",
 		},
 		[]string{"name"},
 	)

--- a/mirror_runner.go
+++ b/mirror_runner.go
@@ -53,6 +53,7 @@ func newMirrorRunner(client, watchClient kubernetes.Interface, name, namespace, 
 	}
 	runner.serviceQueue = newQueue(fmt.Sprintf("%s-service", name), runner.reconcileService)
 	runner.endpointsQueue = newQueue(fmt.Sprintf("%s-endpoints", name), runner.reconcileEndpoints)
+	runnerName := fmt.Sprintf("mirror-%s", name)
 
 	// Create and initialize a service watcher
 	serviceWatcher := kube.NewServiceWatcher(
@@ -62,6 +63,7 @@ func newMirrorRunner(client, watchClient kubernetes.Interface, name, namespace, 
 		runner.ServiceEventHandler,
 		labelselector,
 		metav1.NamespaceAll,
+		runnerName,
 	)
 	runner.serviceWatcher = serviceWatcher
 	runner.serviceWatcher.Init()
@@ -74,6 +76,7 @@ func newMirrorRunner(client, watchClient kubernetes.Interface, name, namespace, 
 		nil,
 		labels.Set(mirrorLabels).String(),
 		namespace,
+		runnerName,
 	)
 	runner.mirrorServiceWatcher = mirrorServiceWatcher
 	runner.mirrorServiceWatcher.Init()
@@ -86,6 +89,7 @@ func newMirrorRunner(client, watchClient kubernetes.Interface, name, namespace, 
 		runner.EndpointsEventHandler,
 		labelselector,
 		metav1.NamespaceAll,
+		runnerName,
 	)
 	runner.endpointsWatcher = endpointsWatcher
 	runner.endpointsWatcher.Init()
@@ -98,6 +102,7 @@ func newMirrorRunner(client, watchClient kubernetes.Interface, name, namespace, 
 		nil,
 		labels.Set(mirrorLabels).String(),
 		namespace,
+		runnerName,
 	)
 	runner.mirrorEndpointsWatcher = mirrorEndpointsWatcher
 	runner.mirrorEndpointsWatcher.Init()


### PR DESCRIPTION
Changing the controller to watch multiple remotes mixed the exported metrics for
kube watchers. This attempts to make labels more clear and introduce an
additional "runner" label to avoid duplicate series. Also, updates the README
with available metrics and an explanation for the watchers metrics labels.