### PR TITLE
Fix GlobalService Deletion

### DIFF
--- a/global_runner.go
+++ b/global_runner.go
@@ -170,6 +170,7 @@ func (gr *GlobalRunner) reconcileGlobalService(name, namespace string) error {
 			if err := kube.DeleteService(gr.ctx, gr.client, globalSvcName, gr.namespace); err != nil && !errors.IsNotFound(err) {
 				return fmt.Errorf("deleting service %s/%s: %v", gr.namespace, globalSvcName, err)
 			}
+			return nil // return on successful service deletion, nothing else to do here.
 		}
 	} else if err != nil {
 		return fmt.Errorf("getting remote service: %v", err)

--- a/global_runner_test.go
+++ b/global_runner_test.go
@@ -413,12 +413,14 @@ func TestDeleteGlobalServiceMultipleClusters(t *testing.T) {
 	}}
 	assertExpectedGlobalServices(ctx, t, expectedSvcs, fakeClient)
 	// Deleting the service from cluster A should only edit the respective label
-	testRunnerA.reconcileGlobalService("test-svc", "remote-ns")
+	err := testRunnerA.reconcileGlobalService("test-svc", "remote-ns")
+	assert.Equal(t, nil, err)
 	expectedSvcs[0].Annotations[globalSvcClustersAnno] = "runnerB"
 	assertExpectedGlobalServices(ctx, t, expectedSvcs, fakeClient)
 
 	// Deleting the service from cluster B should delete the global service
-	testRunnerB.reconcileGlobalService("test-svc", "remote-ns")
+	err = testRunnerB.reconcileGlobalService("test-svc", "remote-ns")
+	assert.Equal(t, nil, err)
 	assertExpectedServices(ctx, t, []TestSvc{}, fakeClient)
 }
 


### PR DESCRIPTION
Reconciling global service deletion events will error and end up looping
forever. Example logs:
```
[ERROR] semaphore-service-mirror: reconcile error: queue=aws-global-service namespace=auth name=iam-proxy-auth err="finding global service in the store: not found"
```
This will make sure we exit the reconcile loop after a successful deletion of
the local representation of a global service.